### PR TITLE
feat: use Microsoft YaHei UI as the application font for Windows

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -17,6 +17,10 @@ int main(int argc, char *argv[])
     QApplication::setApplicationVersion(PROJ_VER);
     QLocale::setDefault(QLocale(QLocale::Chinese, QLocale::SimplifiedChineseScript, QLocale::China));
 
+#ifdef Q_OS_WINDOWS
+    QApplication::setFont(QFont("Microsoft YaHei UI", QApplication::font().pointSize()));
+#endif
+
     QTranslator qtTranslator;
     if (qtTranslator.load(QLocale(QLocale::Chinese, QLocale::SimplifiedChineseScript, QLocale::China),
                           QString("qt"), QString("_"), QLibraryInfo::path(QLibraryInfo::TranslationsPath)))


### PR DESCRIPTION
在非简体中文版的 Windows 系统上，如果不指定字体，中文的显示效果很奇怪：

![image](https://github.com/user-attachments/assets/eda87485-f52c-4bab-96ed-3286ca1d15c0)

设置字体后的效果：

![image](https://github.com/user-attachments/assets/6ddc06b9-2f03-44b1-9722-7f72ca4447bc)