### PR TITLE
feat: 添加重置 ZjuConnect UI 功能并优化连接初始化流程

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -350,6 +350,16 @@ void MainWindow::clearLog()
         "配置路径：" + settings->fileName() + "\n");
 }
 
+void MainWindow::resetZjuConnectUi()
+{
+    isZjuConnectLinked = false;
+    zjuConnectError = ZJU_ERROR::NONE;
+    ui->pushButton1->setText("连接服务器");
+    trayConnectAction->setText("连接服务器");
+    ui->pushButton2->setText("设置系统代理");
+    ui->pushButton2->hide();
+}
+
 void MainWindow::setupTrayIcon()
 {
     // 系统托盘
@@ -539,9 +549,10 @@ bool MainWindow::switchProfile(const QString &profileId)
     currentProfileId = profileId;
     profileManager->setActiveProfile(currentProfileId);
 
-    updateVersionInfo();
     upgradeSettings();
-    initZjuConnect();
+    updateVersionInfo();
+    resetZjuConnectUi();
+    clearLog();
     refreshProfileMenu();
 
     addLog("已切换到配置：" + currentProfileId);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -55,6 +55,8 @@ private:
 
     void clearLog();
 
+    void resetZjuConnectUi();
+
     void showNotification(
         const QString &title,
         const QString &content,
@@ -94,7 +96,7 @@ private:
     QAction *newProfileAction;
     QAction *renameProfileAction;
     QAction *deleteProfileAction;
-    ZjuConnectController *zjuConnectController;
+    ZjuConnectController *zjuConnectController = nullptr;
     QNetworkAccessManager *checkUpdateNAM;
     QNetworkAccessManager *checkCoreUpdateNAM;
     QSettings *settings;

--- a/zjuconnectmode.cpp
+++ b/zjuconnectmode.cpp
@@ -11,14 +11,15 @@
 
 void MainWindow::initZjuConnect()
 {
+    if (zjuConnectController != nullptr)
+    {
+        return;
+    }
+
     clearLog();
 
     zjuConnectController = new ZjuConnectController(this);
-
-    ui->pushButton1->setText("连接服务器");
-    trayConnectAction->setText("连接服务器");
-    ui->pushButton2->setText("设置系统代理");
-    ui->pushButton2->hide();
+    resetZjuConnectUi();
 
     // 连接服务器
     connect(zjuConnectController, &ZjuConnectController::outputRead, this,


### PR DESCRIPTION
1.initZjuConnect() 只允许初始化一次，已有 controller 时直接返回（zjuconnectmode.cpp：L22）
2.新增 resetZjuConnectUi()，集中重置连接按钮、托盘按钮、代理按钮和错误状态（mainwindow.cpp：L353）
3.切换配置时调用 resetZjuConnectUi() 和 clearLog()，不再调用 initZjuConnect()（mainwindow.cpp：552）
4.zjuConnectController 初始化为 nullptr（mainwindow.h：96）