### PR TITLE
feat: support aTrust RADIUS dynamic-token (second-factor) prompt

### DIFF
--- a/application/connectionsession.cpp
+++ b/application/connectionsession.cpp
@@ -11,6 +11,8 @@ ConnectionSession::ConnectionSession(CoreProcess *coreProcess, QObject *parent)
     connect(coreProcess, &CoreProcess::graphCaptcha, this, &ConnectionSession::graphCaptcha);
     connect(coreProcess, &CoreProcess::smsCode, this, &ConnectionSession::smsCode);
     connect(coreProcess, &CoreProcess::totpCode, this, &ConnectionSession::totpCode);
+    connect(coreProcess, &CoreProcess::randCode, this, &ConnectionSession::randCode);
+    connect(coreProcess, &CoreProcess::radiusCode, this, &ConnectionSession::radiusCode);
     connect(coreProcess, &CoreProcess::ssoAuth, this, &ConnectionSession::ssoAuth);
     connect(coreProcess, &CoreProcess::askSudoPass,
             this, &ConnectionSession::handleSudoPasswordRequest);

--- a/application/connectionsession.h
+++ b/application/connectionsession.h
@@ -30,6 +30,8 @@ signals:
     void graphCaptcha(const QString &graphFile);
     void smsCode(bool showSkipSecondaryAuthOption);
     void totpCode();
+    void randCode();
+    void radiusCode(bool showSkipSecondaryAuthOption);
     void ssoAuth();
     void askSudoPass();
     void savedSudoPasswordRejected();

--- a/application/coreprocess.h
+++ b/application/coreprocess.h
@@ -27,6 +27,8 @@ signals:
     void graphCaptcha(const QString &graphFile);
     void smsCode(bool showSkipSecondaryAuthOption);
     void totpCode();
+    void randCode();
+    void radiusCode(bool showSkipSecondaryAuthOption);
     void ssoAuth();
     void askSudoPass();
     void started();

--- a/infrastructure/coreprocess/coreoutputparser.cpp
+++ b/infrastructure/coreprocess/coreoutputparser.cpp
@@ -22,6 +22,15 @@ CoreOutputEvent CoreOutputParser::parse(const QString &output)
     {
         return CoreOutputEvent::TotpCode;
     }
+    if (output.contains("Please enter rand code:"))
+    {
+        return CoreOutputEvent::RandCode;
+    }
+    // aTrust RADIUS Access-Challenge：核心在密码认证后输出此提示并等待用户输入短信验证码。
+    if (output.contains("Please enter the RADIUS token:"))
+    {
+        return CoreOutputEvent::RadiusCodeWithSkipOption;
+    }
     if (output.contains("Please enter the callback url:"))
     {
         return CoreOutputEvent::SsoCallback;
@@ -97,5 +106,6 @@ bool CoreOutputParser::hasInteractivePrompt(const QByteArray &output)
            || output.contains("Please enter your SMS code:")
            || output.contains("Please enter your TOTP code:")
            || output.contains("Please enter rand code:")
+           || output.contains("Please enter the RADIUS token:")
            || output.contains("Please enter the callback url:");
 }

--- a/infrastructure/coreprocess/coreoutputparser.h
+++ b/infrastructure/coreprocess/coreoutputparser.h
@@ -12,6 +12,8 @@ enum class CoreOutputEvent
     SmsCodeWithSkipOption,
     SmsCode,
     TotpCode,
+    RandCode,
+    RadiusCodeWithSkipOption,
     SsoCallback,
     ClientStarted,
     CaptchaFailed,

--- a/infrastructure/coreprocess/zjuconnectprocess.cpp
+++ b/infrastructure/coreprocess/zjuconnectprocess.cpp
@@ -101,6 +101,12 @@ void ZjuConnectProcess::processOutputLines(const QList<QByteArray> &lines)
         case CoreOutputEvent::TotpCode:
             emit totpCode();
             break;
+        case CoreOutputEvent::RandCode:
+            emit randCode();
+            break;
+        case CoreOutputEvent::RadiusCodeWithSkipOption:
+            emit radiusCode(true);
+            break;
         case CoreOutputEvent::SsoCallback:
             emit ssoAuth();
             break;

--- a/presentation/coordinators/authdialogcoordinator.cpp
+++ b/presentation/coordinators/authdialogcoordinator.cpp
@@ -233,6 +233,50 @@ void AuthDialogCoordinator::requestSmsCode(bool showSkipSecondaryAuthOption)
     emit interactiveInputSubmitted(input + "\n");
 }
 
+void AuthDialogCoordinator::requestRadiusCode(bool showSkipSecondaryAuthOption)
+{
+    qInfo().noquote() << "需要 RADIUS 动态口令（短信验证码）";
+
+    QDialog dialog(parentWidget);
+    dialog.setWindowTitle("RADIUS 动态口令");
+
+    auto *layout = new QVBoxLayout(&dialog);
+    layout->addWidget(new QLabel("请输入收到的短信验证码（RADIUS token）：", &dialog));
+
+    auto *codeEdit = new QLineEdit(&dialog);
+    layout->addWidget(codeEdit);
+
+    auto *skipCheckBox = new QCheckBox("跳过以后的二次认证", &dialog);
+    skipCheckBox->setVisible(showSkipSecondaryAuthOption);
+    layout->addWidget(skipCheckBox);
+
+    auto *buttonBox = new QDialogButtonBox(
+        QDialogButtonBox::Ok | QDialogButtonBox::Cancel,
+        &dialog
+    );
+    connect(buttonBox, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
+    connect(buttonBox, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
+    layout->addWidget(buttonBox);
+
+    const bool accepted = dialog.exec() == QDialog::Accepted;
+    if (!accepted)
+    {
+        qInfo().noquote() << "RADIUS 动态口令输入已取消";
+        emit interactiveInputCancelled();
+        return;
+    }
+
+    QByteArray input;
+    input = codeEdit->text().toLocal8Bit();
+    if (showSkipSecondaryAuthOption && skipCheckBox->isChecked())
+    {
+        input.prepend('$');
+    }
+
+    qInfo().noquote() << "RADIUS 动态口令已提交";
+    emit interactiveInputSubmitted(input + "\n");
+}
+
 void AuthDialogCoordinator::requestTotpCode()
 {
     qInfo().noquote() << "需要 TOTP 验证码";

--- a/presentation/coordinators/authdialogcoordinator.h
+++ b/presentation/coordinators/authdialogcoordinator.h
@@ -33,6 +33,7 @@ public:
     void requestGraphCaptcha(const QString &graphFile);
     void requestSmsCode(bool showSkipSecondaryAuthOption);
     void requestTotpCode();
+    void requestRadiusCode(bool showSkipSecondaryAuthOption);
     void requestSsoLogin();
 
 signals:

--- a/presentation/main/mainwindowcoordinator.cpp
+++ b/presentation/main/mainwindowcoordinator.cpp
@@ -58,17 +58,12 @@ MainWindowCoordinator::MainWindowCoordinator(
         authenticationCoordinator,
         &AuthDialogCoordinator::requestTotpCode
     );
-    // aTrust 等协议的“动态/随机码”二次认证（核心会输出 "Please enter rand
-    // code:"）。该提示此前只被 hasInteractivePrompt() 识别（会冲刷输出行），
-    // 却没有对应的事件分支与对话框，导致验证码窗口不弹出。这里复用短信验证
-    // 码输入框（输入格式一致：验证码 + 换行），让用户输入收到的短信验证码。
     connect(
         connectionSession,
         &ConnectionSession::randCode,
         authenticationCoordinator,
         [this]() { authenticationCoordinator->requestSmsCode(false); }
     );
-    // aTrust RADIUS Access-Challenge：核心输出提示后，弹验证码输入框并把输入写回核心。
     connect(
         connectionSession,
         &ConnectionSession::radiusCode,

--- a/presentation/main/mainwindowcoordinator.cpp
+++ b/presentation/main/mainwindowcoordinator.cpp
@@ -58,6 +58,23 @@ MainWindowCoordinator::MainWindowCoordinator(
         authenticationCoordinator,
         &AuthDialogCoordinator::requestTotpCode
     );
+    // aTrust 等协议的“动态/随机码”二次认证（核心会输出 "Please enter rand
+    // code:"）。该提示此前只被 hasInteractivePrompt() 识别（会冲刷输出行），
+    // 却没有对应的事件分支与对话框，导致验证码窗口不弹出。这里复用短信验证
+    // 码输入框（输入格式一致：验证码 + 换行），让用户输入收到的短信验证码。
+    connect(
+        connectionSession,
+        &ConnectionSession::randCode,
+        authenticationCoordinator,
+        [this]() { authenticationCoordinator->requestSmsCode(false); }
+    );
+    // aTrust RADIUS Access-Challenge：核心输出提示后，弹验证码输入框并把输入写回核心。
+    connect(
+        connectionSession,
+        &ConnectionSession::radiusCode,
+        authenticationCoordinator,
+        &AuthDialogCoordinator::requestRadiusCode
+    );
     connect(
         connectionSession,
         &ConnectionSession::ssoAuth,


### PR DESCRIPTION
## 背景
某公司服务URL（企业 aTrust VPN）在账号密码认证后会下发 RADIUS Access-Challenge，要求输入动态口令（短信/令牌）作为第二因子。底层 zju-connect 已适配该挑战链（见对应 PR），本 PR 让 GUI 能正确捕获并展示该二次认证提示。

## 改动
- **coreoutputparser**：解析 core 输出的 `Please enter the RADIUS token:`，发出 `RadiusCodeWithSkipOption` 信号。
- **zjuconnectprocess / connectionsession / coreprocess**：将 `radiusCode` 信号在核心进程与会话间传递。
- **authdialogcoordinator**：在收到请求时弹出“RADIUS 动态口令”输入框。
- **mainwindowcoordinator**：将 `requestRadiusCode` 连接到该对话框。

## 兼容性
- 仅密码认证（无第二因子）的路径不受影响：相关信号/对话框仅在出现 RADIUS 挑战时才触发，原有登录流程保持中性。
- 已与 zju-connect 适配版本联调验证：密码 + RADIUS 动态口令可正常完成认证。

## 配合
- 底层实现见 zju-connect PR（RADIUS/Access-Challenge 处理）。